### PR TITLE
Parallelise prediction.

### DIFF
--- a/diagonal_pets/__init__.py
+++ b/diagonal_pets/__init__.py
@@ -15,7 +15,7 @@ from diagonal_pets.model import make_model
 from diagonal_pets.model import make_batch
 from diagonal_pets.model import generate_fake_data
 from diagonal_pets.model import fit
-from diagonal_pets.model import predict
+from diagonal_pets.model import predict, predict_parallel
 from diagonal_pets.model import WINDOW
 
 from diagonal_pets.progress import track, dont_track

--- a/diagonal_pets/data.py
+++ b/diagonal_pets/data.py
@@ -61,8 +61,11 @@ class FileData:
     def rotate_key_filename(self):
         return self._local_filename("rotate.key", prefixed=False)
 
-    def preds_dest_filename(self):
-        return self.preds_dest_path
+    def preds_dest_filename(self, shard=0, shards=1):
+        if shard == 0 and shards == 1:
+            return self.preds_dest_path
+        else:
+            return self.preds_dest_path.with_stem(self.preds_dest_path.stem + (".%d-of-%d" % (shard, shards)))
 
     def _local_filename(self, name, prefixed=True):
         path = self.client_dir or self.server_dir or self.model_dir

--- a/diagonal_pets/federated.py
+++ b/diagonal_pets/federated.py
@@ -204,10 +204,9 @@ class FitClient(Client):
 
 class TestClient(Client):
 
-    def __init__(self, id, h, ctxt, **args):
+    def __init__(self, id, h, **args):
         self.id = id
         self.h = h
-        self.ctxt = ctxt
         self.data = diagonal_pets.make_file_data(**args)
         diagonal_pets.init_pyfhel(self.h)
 
@@ -216,7 +215,7 @@ class TestClient(Client):
         return GetParametersRes(Status(Code.OK, "ok"), parameters)
 
     def evaluate(self, ins):
-        diagonal_pets.predict(self.h, self.ctxt, self.data, diagonal_pets.track)
+        diagonal_pets.predict_parallel(self.h, self.data)
         return EvaluateRes(Status(Code.OK, "ok"), 0.0, 0, {})
 
 class TestStrategy(Strategy):

--- a/solution_centralized.py
+++ b/solution_centralized.py
@@ -66,11 +66,9 @@ def fit(fake_pyfhel=FAKE_PYFHEL, **args):
     aggregator.clear_infected_visits(0, FIT_STOP_DAY - diagonal_pets.WINDOW)
 
 def predict(fake_pyfhel=FAKE_PYFHEL, **args):
-    h, ctxt = diagonal_pets.make_pyfhel(fake_pyfhel)
-    diagonal_pets.init_pyfhel(h)
+    h, _ = diagonal_pets.make_pyfhel(fake_pyfhel)
     data = diagonal_pets.make_file_data(**args)
-    diagonal_pets.read_keys(data, h)
-    return diagonal_pets.predict(h, ctxt, data, diagonal_pets.track)
+    diagonal_pets.predict_parallel(h, data)
 
 def score(score_prefix, **args):
     import matplotlib.pyplot as plt

--- a/solution_federated.py
+++ b/solution_federated.py
@@ -59,11 +59,11 @@ def test_strategy_factory(server_dir, fake_pyfhel=FAKE_PYFHEL, prefix="dw"):
     return diagonal_pets.TestStrategy(), diagonal_pets.TEST_ROUNDS
 
 def test_client_factory(cid, fake_pyfhel=FAKE_PYFHEL, client_dir=None, **args):
-    h, ctxt = diagonal_pets.make_pyfhel(fake_pyfhel)
+    h, _ = diagonal_pets.make_pyfhel(fake_pyfhel)
     diagonal_pets.init_pyfhel(h)
     data = diagonal_pets.make_file_data(client_dir=client_dir)
     diagonal_pets.read_keys(data, h, secret=True, public=True, rotate=True)
-    return diagonal_pets.TestClient(cid, h, ctxt, client_dir=client_dir, **args)
+    return diagonal_pets.TestClient(cid, h, client_dir=client_dir, **args)
 
 def paths_from_flags(flags, cid):
     input = Path(flags.input)


### PR DESCRIPTION
Parallelise prediction, using processes writing separate files to avoid the GIL. Also bias more towards training examples of infected places (based on tests), and remove a redundant sum in read().